### PR TITLE
fixed i3lock outdated arguments

### DIFF
--- a/glitchlock
+++ b/glitchlock
@@ -23,10 +23,10 @@ steps=$(shuf -i 40-70 -n 1)
 for i in $(seq 1 $steps);do datamosh "$file"; done
 
 GLITCHICON=${GLITCHICON:=""}
-PARAM=(--bar-indicator --bar-position h --bar-direction 1 --redraw-thread -t "" \
-	--bar-step 50 --bar-width 250 --bar-base-width 50 --bar-max-height 100 --bar-periodic-step 50 \
-	--bar-color 00000077 --keyhlcolor 00666666 --ringvercolor cc87875f --wrongcolor ffff0000 \
-	--veriftext="" --wrongtext="" --noinputtext="" )
+PARAM=(--bar-indicator --bar-orientation horizontal --bar-direction 1 --redraw-thread -t "" \
+	--bar-step 50 --bar-total-width 250 --bar-base-width 50 --bar-max-height 100 --bar-periodic-step 50 \
+	--bar-color 00000077 --keyhl-color 00666666 --ringver-color cc87875f --wrong-color ffff0000 \
+	--verif-text="" --wrong-text="" --noinput-text="" )
 
 LOCK=()
 while read LINE


### PR DESCRIPTION
i3lock arguments have changed, and the command fails at present state with i3lock version aur-4ff79c0

This resolves the invalid arguments.